### PR TITLE
beacon-chain/blockchain: improve logging

### DIFF
--- a/beacon-chain/blockchain/CHANGELOG.md
+++ b/beacon-chain/blockchain/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
+
+## [Unreleased]
+
+### Added
+
+- New attestation verification metrics tracking system
+    - Added `AttestationMetricsCollector` interface for collecting attestation verification stats
+    - Added thread-safe `metricsCollector` implementation
+    - Added new Prometheus metrics:
+        - `attestation_verification_success_total`: Counter for successful attestation verifications
+        - `attestation_verification_failure_total`: Counter for failed attestation verifications
+        - `attestation_verification_failure_reasons_total`: Counter vector for failure reasons
+    - Added structured logging of attestation stats per epoch
+    - Added epoch-level attestation metrics including:
+        - Success/failure counts
+        - Success rate percentage
+        - Failure reasons breakdown
+        - Total processed attestations
+
+### Changed
+
+- Enhanced `reportEpochMetrics` to include attestation verification statistics
+- Added attestation stats collection integration in block processing pipeline
+
+### Added Tests
+
+- Comprehensive test suite for attestation metrics collector:
+    - Basic success/failure recording
+    - Concurrent access testing
+    - Epoch advancement and metrics reset
+    - Metrics accuracy verification

--- a/beacon-chain/blockchain/README.md
+++ b/beacon-chain/blockchain/README.md
@@ -1,0 +1,65 @@
+# Attestation Verification Metrics System
+
+## Overview
+
+This solution implements a metrics collection system for tracking attestation verification performance in Prysm beacon
+nodes.
+
+## Implementation Details
+
+### Core Components
+
+1. **AttestationMetricsCollector Interface**
+    - Defines the contract for recording attestation verification outcomes
+    - Provides methods for recording successes and failures
+    - Handles epoch transitions and metrics retrieval
+
+2. **Thread-safe MetricsCollector Implementation**
+    - Uses mutex for thread safety
+    - Tracks:
+        - Success/failure counts
+        - Failure reasons with counts
+        - Current epoch
+        - Success rate calculations
+    - Provides atomic operations for concurrent access
+
+3. **Integration Points**
+    - Integrated in `reportEpochMetrics` in blockchain service
+    - Hooks into existing epoch boundary processing
+    - Leverages existing prometheus metrics infrastructure
+
+### Why This Approach?
+
+1. **Location Choice**
+    - Integrated into `reportEpochMetrics` because:
+        - Already handles epoch-level metrics
+        - Has access to necessary state information
+        - Natural point for epoch-boundary processing
+        - Minimizes code changes and complexity
+
+2. **Data Structure Design**
+    - Separate interface and implementation for:
+        - Better testing capabilities
+        - Clear contract definition
+        - Future extensibility
+        - Dependency injection
+
+### What could I improve?
+
+- Separate a better place for metrics. We could move this a level up to `metrics`, but I decided to put it here because:
+    - “Outputs a summary of the collected data at the end of each epoch.” The requirement indicated a place as close as
+      possible to the end of each epoch.
+    - Doesn't interfere too much with the code, no complex changes needed.
+
+    - When handling more attestation verifications (e.g., sync module), a shared interface and metrics with appropriate
+      namespace would be useful.
+
+- error handling. I added base error handlers, for critical components. This can be extended to a higher level (I didn't
+  want to disturb the readability of the code, with not much code interference)
+
+- adding configuration, making metrics collector service with context support
+- adding limitation:
+    - length of reasons
+    - watching for overflow
+    - checking if the collector works
+- prysm uses tracing, so this can be added to the tracking too

--- a/beacon-chain/blockchain/attestation_stats.go
+++ b/beacon-chain/blockchain/attestation_stats.go
@@ -2,7 +2,6 @@ package blockchain
 
 import (
 	"sync"
-	"time"
 
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 )
@@ -33,7 +32,7 @@ type StatsCollector interface {
 }
 
 // attestationStats handles attestation verification statistics collection.
-// It keeps track of successful and failed attestations, along with failure reasonsdd
+// It keeps track of successful and failed attestations, along with failure reasonsddoc
 // and provides thread-safe access to these statistics.
 type attestationStats struct {
 	mu             sync.RWMutex
@@ -57,8 +56,6 @@ func (as *attestationStats) recordSuccess() {
 	defer as.mu.Unlock()
 
 	as.successCount++
-
-	attestationVerificationSuccess.Inc()
 }
 
 // recordFailure increments the failed attestation counter and records the failure reason.
@@ -76,16 +73,6 @@ func (as *attestationStats) recordFailure(reason string) {
 
 	as.failureCount++
 	as.failureReasons[reason]++
-
-	attestationVerificationFailure.Inc()
-	attestationVerificationFailureReasons.WithLabelValues(reason).Inc()
-}
-
-// recordLatency records the duration of attestation verification.
-// Parameters:
-//   - duration: The time taken to verify the attestation
-func (as *attestationStats) recordLatency(duration time.Duration) {
-	attestationVerificationLatency.Observe(duration.Seconds())
 }
 
 // getStats returns the current attestation verification statistics.

--- a/beacon-chain/blockchain/attestation_stats.go
+++ b/beacon-chain/blockchain/attestation_stats.go
@@ -1,0 +1,152 @@
+package blockchain
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+)
+
+const (
+	percentFactor = 100
+)
+
+// EpochSummary represents a summary of attestation stats for a single epoch.
+type EpochSummary struct {
+	Epoch          primitives.Epoch
+	Successes      uint64
+	Failures       uint64
+	SuccessRate    float64
+	TotalProcessed uint64
+	FailureReasons map[string]uint64
+	ResetOccurred  bool
+}
+
+// StatsCollector defines the interface for collecting attestation statistics.
+type StatsCollector interface {
+	// recordSuccess records a successful attestation verification.
+	recordSuccess()
+	// recordFailure records a failed attestation verification with a reason.
+	recordFailure(reason string)
+	// getStats returns current statistics about attestation verifications.
+	getStats() (uint64, uint64, map[string]uint64)
+}
+
+// attestationStats handles attestation verification statistics collection.
+// It keeps track of successful and failed attestations, along with failure reasonsdd
+// and provides thread-safe access to these statistics.
+type attestationStats struct {
+	mu             sync.RWMutex
+	successCount   uint64
+	failureCount   uint64
+	failureReasons map[string]uint64
+	lastEpoch      primitives.Epoch
+}
+
+// New creates a new attestationStats instance.
+func newAttestationStats() *attestationStats {
+	return &attestationStats{
+		failureReasons: make(map[string]uint64),
+	}
+}
+
+// recordSuccess increments the successful attestation counter and updates related metrics.
+// This method is thread-safe and can be called concurrently from multiple goroutines.
+func (as *attestationStats) recordSuccess() {
+	as.mu.Lock()
+	defer as.mu.Unlock()
+
+	as.successCount++
+
+	attestationVerificationSuccess.Inc()
+}
+
+// recordFailure increments the failed attestation counter and records the failure reason.
+// This method is thread-safe and can be called concurrently from multiple goroutines.
+// If an empty reason is provided, it will be recorded as "unknown".
+// Parameters:
+//   - reason: The reason for the attestation verification failure
+func (as *attestationStats) recordFailure(reason string) {
+	as.mu.Lock()
+	defer as.mu.Unlock()
+
+	if reason == "" {
+		reason = "unknown"
+	}
+
+	as.failureCount++
+	as.failureReasons[reason]++
+
+	attestationVerificationFailure.Inc()
+	attestationVerificationFailureReasons.WithLabelValues(reason).Inc()
+}
+
+// recordLatency records the duration of attestation verification.
+// Parameters:
+//   - duration: The time taken to verify the attestation
+func (as *attestationStats) recordLatency(duration time.Duration) {
+	attestationVerificationLatency.Observe(duration.Seconds())
+}
+
+// getStats returns the current attestation verification statistics.
+// The returned map is a copy of the internal failure reasons map, making it safe for concurrent access.
+// Returns:
+//   - successCount: Number of successful attestation verifications
+//   - failureCount: Number of failed attestation verifications
+//   - failureReasons: Map of failure reasons and their counts
+func (as *attestationStats) getStats() (uint64, uint64, map[string]uint64) {
+	as.mu.RLock()
+	defer as.mu.RUnlock()
+
+	failureCopy := make(map[string]uint64, len(as.failureReasons))
+
+	for k, v := range as.failureReasons {
+		failureCopy[k] = v
+	}
+
+	return as.successCount, as.failureCount, failureCopy
+}
+
+// outputEpochSummary computes and returns the statistics for the given epoch.
+// If currentEpoch > as.lastEpoch, the internal counters are reset.
+func (as *attestationStats) outputEpochSummary(currentEpoch primitives.Epoch) EpochSummary {
+	as.mu.Lock()
+	defer as.mu.Unlock()
+
+	total := as.successCount + as.failureCount
+	successRate := float64(0)
+	if total > 0 {
+		successRate = float64(as.successCount) / float64(total) * percentFactor
+	}
+
+	reasonsCopy := make(map[string]uint64, len(as.failureReasons))
+	for k, v := range as.failureReasons {
+		reasonsCopy[k] = v
+	}
+
+	summary := EpochSummary{
+		Epoch:          currentEpoch,
+		Successes:      as.successCount,
+		Failures:       as.failureCount,
+		SuccessRate:    successRate,
+		TotalProcessed: total,
+		FailureReasons: reasonsCopy,
+		ResetOccurred:  false,
+	}
+
+	if currentEpoch > as.lastEpoch {
+		as.reset()
+		as.lastEpoch = currentEpoch
+		summary.ResetOccurred = true
+	}
+
+	return summary
+}
+
+// reset resets the internal counters and failure reasons map.
+// Caller must hold the write lock.
+func (as *attestationStats) reset() {
+	as.successCount = 0
+	as.failureCount = 0
+	as.failureReasons = make(map[string]uint64)
+}

--- a/beacon-chain/blockchain/attestation_stats_test.go
+++ b/beacon-chain/blockchain/attestation_stats_test.go
@@ -1,0 +1,157 @@
+package blockchain
+
+import (
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v5/testing/require"
+	"sync"
+	"testing"
+)
+
+func TestAttestationStats_RecordSuccess(t *testing.T) {
+	t.Parallel()
+
+	stats := newAttestationStats()
+
+	stats.recordSuccess()
+	successes, _, _ := stats.getStats()
+	require.Equal(t, uint64(1), successes)
+
+	for i := 0; i < 5; i++ {
+		stats.recordSuccess()
+	}
+
+	successes, _, _ = stats.getStats()
+	require.Equal(t, uint64(6), successes)
+}
+
+func TestAttestationStats_RecordFailure(t *testing.T) {
+	t.Parallel()
+
+	stats := newAttestationStats()
+
+	stats.recordFailure("decode_error")
+	stats.recordFailure("invalid_signature")
+	stats.recordFailure("invalid_signature")
+	stats.recordFailure("invalid_committee_index")
+
+	_, failures, reasons := stats.getStats()
+	require.Equal(t, uint64(4), failures)
+	require.Equal(t, uint64(1), reasons["decode_error"])
+	require.Equal(t, uint64(2), reasons["invalid_signature"])
+	require.Equal(t, uint64(1), reasons["invalid_committee_index"])
+}
+
+func TestAttestationStats_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	stats := newAttestationStats()
+
+	const (
+		workers    = 100
+		iterations = 100
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	failureReasons := []string{
+		"decode_error",
+		"invalid_signature",
+		"invalid_committee_index",
+		"nil_attestation",
+		"wrong_message_type",
+	}
+
+	for i := 0; i < workers; i++ {
+		go func(workerID int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				if j%2 == 0 {
+					stats.recordSuccess()
+				} else {
+					reason := failureReasons[j%len(failureReasons)]
+					stats.recordFailure(reason)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	successes, failures, reasons := stats.getStats()
+	expectedTotal := uint64(workers * iterations)
+	actualTotal := successes + failures
+
+	require.Equal(t, expectedTotal, actualTotal)
+
+	for _, reason := range failureReasons {
+		count := reasons[reason]
+		require.NotEqual(t, uint64(0), count, "Failure reason "+reason+" did not occur")
+	}
+
+	var totalReasonCounts uint64
+	for _, count := range reasons {
+		totalReasonCounts += count
+	}
+	require.Equal(t, failures, totalReasonCounts)
+
+	require.NotEqual(t, uint64(0), successes)
+	require.NotEqual(t, uint64(0), failures)
+	require.NotEqual(t, expectedTotal, failures)
+	require.NotEqual(t, expectedTotal, successes)
+}
+
+func TestAttestationStats_OutputEpochSummary(t *testing.T) {
+	t.Parallel()
+
+	stats := newAttestationStats()
+
+	stats.recordSuccess()
+	stats.recordSuccess()
+	stats.recordFailure("decode_error")
+	stats.recordFailure("invalid_signature")
+
+	stats.outputEpochSummary(primitives.Epoch(1))
+
+	successes, failures, reasons := stats.getStats()
+	require.Equal(t, uint64(0), successes)
+	require.Equal(t, uint64(0), failures)
+	require.Equal(t, 0, len(reasons))
+	require.Equal(t, primitives.Epoch(1), stats.lastEpoch)
+
+	stats.recordSuccess()
+	stats.recordFailure("decode_error")
+	stats.outputEpochSummary(primitives.Epoch(1))
+
+	successes, failures, reasons = stats.getStats()
+	require.Equal(t, uint64(1), successes)
+	require.Equal(t, uint64(1), failures)
+	require.Equal(t, uint64(1), reasons["decode_error"])
+
+	stats.outputEpochSummary(primitives.Epoch(2))
+	successes, failures, reasons = stats.getStats()
+	require.Equal(t, uint64(0), successes)
+	require.Equal(t, uint64(0), failures)
+	require.Equal(t, 0, len(reasons))
+	require.Equal(t, primitives.Epoch(2), stats.lastEpoch)
+}
+
+func TestAttestationStats_GetStats(t *testing.T) {
+	t.Parallel()
+
+	stats := newAttestationStats()
+
+	stats.recordSuccess()
+	stats.recordFailure("decode_error")
+	stats.recordFailure("decode_error")
+	stats.recordFailure("invalid_signature")
+
+	successes, failures, reasons := stats.getStats()
+	require.Equal(t, uint64(1), successes)
+	require.Equal(t, uint64(3), failures)
+	require.Equal(t, uint64(2), reasons["decode_error"])
+	require.Equal(t, uint64(1), reasons["invalid_signature"])
+
+	reasons["decode_error"] = 999
+	_, _, newReasons := stats.getStats()
+	require.Equal(t, uint64(2), newReasons["decode_error"])
+}

--- a/beacon-chain/blockchain/attestation_stats_test.go
+++ b/beacon-chain/blockchain/attestation_stats_test.go
@@ -115,8 +115,9 @@ func TestMetricsCollector_AdvanceEpoch(t *testing.T) {
 	collector.RecordFailure("decode_error")
 	collector.RecordFailure("invalid_signature")
 
-	oldMetrics := collector.AdvanceEpoch(primitives.Epoch(1))
+	oldMetrics, err := collector.AdvanceEpoch(primitives.Epoch(1))
 
+	require.NoError(t, err)
 	require.Equal(t, primitives.Epoch(0), oldMetrics.Epoch)
 	require.Equal(t, uint64(2), oldMetrics.Successes)
 	require.Equal(t, uint64(2), oldMetrics.Failures)
@@ -132,8 +133,9 @@ func TestMetricsCollector_AdvanceEpoch(t *testing.T) {
 	collector.RecordSuccess()
 	collector.RecordFailure("decode_error")
 
-	oldMetrics = collector.AdvanceEpoch(primitives.Epoch(2))
+	oldMetrics, err = collector.AdvanceEpoch(primitives.Epoch(2))
 
+	require.NoError(t, err)
 	require.Equal(t, primitives.Epoch(1), oldMetrics.Epoch)
 	require.Equal(t, uint64(1), oldMetrics.Successes)
 	require.Equal(t, uint64(1), oldMetrics.Failures)

--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -386,7 +386,16 @@ func reportEpochMetrics(ctx context.Context, postState, headState state.BeaconSt
 		return nil
 	}
 
-	summary := stats.AdvanceEpoch(currentEpoch)
+	summary, err := stats.AdvanceEpoch(currentEpoch)
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			"error":     err,
+			"epoch":     currentEpoch,
+			"component": "attestation_metrics",
+		}).Error("Failed to advance metrics epoch")
+		return nil
+	}
+
 	reportAttestationStats(summary)
 
 	return nil

--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -221,6 +221,28 @@ var (
 			Buckets: []float64{1, 2, 4, 8, 16, 32},
 		},
 	)
+	attestationVerificationSuccess = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "attestation_verification_success_total",
+		Help: "The total number of successfully verified attestations",
+	})
+	attestationVerificationFailure = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "attestation_verification_failure_total",
+		Help: "The total number of failed attestation verifications",
+	})
+	attestationVerificationFailureReasons = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "attestation_verification_failure_reasons_total",
+			Help: "The total number of attestation verification failures by reason",
+		},
+		[]string{"reason"},
+	)
+	attestationVerificationLatency = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "attestation_verification_latency_seconds",
+			Help:    "Latency of attestation verification in seconds",
+			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		},
+	)
 )
 
 // reportSlotMetrics reports slot related metrics.

--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -3,6 +3,7 @@ package blockchain
 import (
 	"context"
 	"fmt"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/pkg/errors"
@@ -381,10 +382,12 @@ func reportEpochMetrics(ctx context.Context, postState, headState state.BeaconSt
 	}
 	postState.RecordStateMetrics()
 
-	if stats != nil {
-		summary := stats.AdvanceEpoch(currentEpoch)
-		reportAttestationStats(summary)
+	if stats == nil {
+		return nil
 	}
+
+	summary := stats.AdvanceEpoch(currentEpoch)
+	reportAttestationStats(summary)
 
 	return nil
 }
@@ -395,6 +398,9 @@ func reportAttestationInclusion(blk interfaces.ReadOnlyBeaconBlock) {
 	}
 }
 
+// reportAttestationStats reports attestation verification statistics for a completed epoch
+// to both the logger and Prometheus metrics. It tracks the total number of successful and failed
+// attestation verifications, along with specific failure reasons and success rates.
 func reportAttestationStats(summary AttestationMetrics) {
 	log.WithFields(logrus.Fields{
 		"epoch":          summary.Epoch,

--- a/beacon-chain/blockchain/metrics_test.go
+++ b/beacon-chain/blockchain/metrics_test.go
@@ -15,7 +15,7 @@ func TestReportEpochMetrics_BadHeadState(t *testing.T) {
 	h, err := util.NewBeaconState()
 	require.NoError(t, err)
 	require.NoError(t, h.SetValidators(nil))
-	err = reportEpochMetrics(context.Background(), s, h)
+	err = reportEpochMetrics(context.Background(), s, h, nil)
 	require.ErrorContains(t, "failed to initialize precompute: state has nil validator slice", err)
 }
 
@@ -25,7 +25,7 @@ func TestReportEpochMetrics_BadAttestation(t *testing.T) {
 	h, err := util.NewBeaconState()
 	require.NoError(t, err)
 	require.NoError(t, h.AppendCurrentEpochAttestations(&eth.PendingAttestation{InclusionDelay: 0}))
-	err = reportEpochMetrics(context.Background(), s, h)
+	err = reportEpochMetrics(context.Background(), s, h, nil)
 	require.ErrorContains(t, "attestation with inclusion delay of 0", err)
 }
 
@@ -36,6 +36,6 @@ func TestReportEpochMetrics_SlashedValidatorOutOfBound(t *testing.T) {
 	v.Slashed = true
 	require.NoError(t, h.UpdateValidatorAtIndex(0, v))
 	require.NoError(t, h.AppendCurrentEpochAttestations(&eth.PendingAttestation{InclusionDelay: 1, Data: util.HydrateAttestationData(&eth.AttestationData{})}))
-	err = reportEpochMetrics(context.Background(), h, h)
+	err = reportEpochMetrics(context.Background(), h, h, nil)
 	require.ErrorContains(t, "slot 0 out of bounds", err)
 }

--- a/beacon-chain/blockchain/process_attestation.go
+++ b/beacon-chain/blockchain/process_attestation.go
@@ -41,9 +41,11 @@ func (s *Service) OnAttestation(ctx context.Context, a ethpb.Att, disparity time
 	defer span.End()
 
 	if err := helpers.ValidateNilAttestation(a); err != nil {
+		s.attestationStats.recordFailure("nil_attestation")
 		return err
 	}
 	if err := helpers.ValidateSlotTargetEpoch(a.GetData()); err != nil {
+		s.attestationStats.recordFailure("invalid_slot_target_epoch")
 		return err
 	}
 	tgt := a.GetData().Target.Copy()
@@ -56,6 +58,7 @@ func (s *Service) OnAttestation(ctx context.Context, a ethpb.Att, disparity time
 	// save it to the cache.
 	baseState, err := s.getAttPreState(ctx, tgt)
 	if err != nil {
+		s.attestationStats.recordFailure("invalid_pre_state")
 		return err
 	}
 
@@ -63,11 +66,13 @@ func (s *Service) OnAttestation(ctx context.Context, a ethpb.Att, disparity time
 
 	// Verify attestation target is from current epoch or previous epoch.
 	if err := verifyAttTargetEpoch(ctx, genesisTime, uint64(time.Now().Add(disparity).Unix()), tgt); err != nil {
+		s.attestationStats.recordFailure("invalid_target_epoch")
 		return err
 	}
 
 	// Verify attestation beacon block is known and not from the future.
 	if err := s.verifyBeaconBlock(ctx, a.GetData()); err != nil {
+		s.attestationStats.recordFailure("invalid_beacon_block")
 		return errors.Wrap(err, "could not verify attestation beacon block")
 	}
 
@@ -76,19 +81,23 @@ func (s *Service) OnAttestation(ctx context.Context, a ethpb.Att, disparity time
 
 	// Verify attestations can only affect the fork choice of subsequent slots.
 	if err := slots.VerifyTime(genesisTime, a.GetData().Slot+1, disparity); err != nil {
+		s.attestationStats.recordFailure("invalid_time")
 		return err
 	}
 
 	// Use the target state to verify attesting indices are valid.
 	committees, err := helpers.AttestationCommittees(ctx, baseState, a)
 	if err != nil {
+		s.attestationStats.recordFailure("invalid_committees")
 		return err
 	}
 	indexedAtt, err := attestation.ConvertToIndexed(ctx, a, committees...)
 	if err != nil {
+		s.attestationStats.recordFailure("conversion_failed")
 		return err
 	}
 	if err := attestation.IsValidAttestationIndices(ctx, indexedAtt); err != nil {
+		s.attestationStats.recordFailure("invalid_indices")
 		return err
 	}
 
@@ -98,6 +107,8 @@ func (s *Service) OnAttestation(ctx context.Context, a ethpb.Att, disparity time
 
 	// Update forkchoice store with the new attestation for updating weight.
 	s.cfg.ForkChoiceStore.ProcessAttestation(ctx, indexedAtt.GetAttestingIndices(), bytesutil.ToBytes32(a.GetData().BeaconBlockRoot), a.GetData().Target.Epoch)
+
+	s.attestationStats.recordSuccess()
 
 	return nil
 }

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -165,7 +165,7 @@ func (s *Service) updateCheckpoints(
 		if err != nil {
 			return errors.Wrap(err, "could not get head state")
 		}
-		if err := reportEpochMetrics(ctx, postState, headSt); err != nil {
+		if err := reportEpochMetrics(ctx, postState, headSt, s.attestationStats); err != nil {
 			log.WithError(err).Error("could not report epoch metrics")
 		}
 	}

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -65,7 +65,7 @@ type Service struct {
 	blobNotifiers        *blobNotifierMap
 	blockBeingSynced     *currentlySyncingBlock
 	blobStorage          *filesystem.BlobStorage
-	attestationStats     *attestationStats
+	attestationStats     AttestationMetricsCollector
 }
 
 // config options for the service.
@@ -178,7 +178,7 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 		blobNotifiers:        bn,
 		cfg:                  &config{},
 		blockBeingSynced:     &currentlySyncingBlock{roots: make(map[[32]byte]struct{})},
-		attestationStats:     newAttestationStats(),
+		attestationStats:     NewMetricsCollector(),
 	}
 	for _, opt := range opts {
 		if err := opt(srv); err != nil {

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -65,6 +65,7 @@ type Service struct {
 	blobNotifiers        *blobNotifierMap
 	blockBeingSynced     *currentlySyncingBlock
 	blobStorage          *filesystem.BlobStorage
+	attestationStats     *attestationStats
 }
 
 // config options for the service.
@@ -177,6 +178,7 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 		blobNotifiers:        bn,
 		cfg:                  &config{},
 		blockBeingSynced:     &currentlySyncingBlock{roots: make(map[[32]byte]struct{})},
+		attestationStats:     newAttestationStats(),
 	}
 	for _, opt := range opts {
 		if err := opt(srv); err != nil {


### PR DESCRIPTION
# Attestation Verification Metrics System

## Overview

This solution implements a metrics collection system for tracking attestation verification performance in Prysm beacon
nodes.

Edit: metrics could be added on a higher lvl, like. `receiveAttestationNoPubsub/processAttestations`, but we want to categorize the reasons.

## Implementation Details

### Core Components

1. **AttestationMetricsCollector Interface**
    - Defines the contract for recording attestation verification outcomes
    - Provides methods for recording successes and failures
    - Handles epoch transitions and metrics retrieval

2. **Thread-safe MetricsCollector Implementation**
    - Uses mutex for thread safety
    - Tracks:
        - Success/failure counts
        - Failure reasons with counts
        - Current epoch
        - Success rate calculations
    - Provides atomic operations for concurrent access

3. **Integration Points**
    - Integrated in `reportEpochMetrics` in blockchain service
    - Hooks into existing epoch boundary processing
    - Leverages existing prometheus metrics infrastructure

### Why This Approach?

1. **Location Choice**
    - Integrated into `reportEpochMetrics` because:
        - Already handles epoch-level metrics
        - Has access to necessary state information
        - Natural point for epoch-boundary processing
        - Minimizes code changes and complexity

2. **Data Structure Design**
    - Separate interface and implementation for:
        - Better testing capabilities
        - Clear contract definition
        - Future extensibility
        - Dependency injection

### What could I improve?

- Separate a better place for metrics. We could move this a level up to `metrics`, but I decided to put it here because:
    - “Outputs a summary of the collected data at the end of each epoch.” The requirement indicated a place as close as
      possible to the end of each epoch.
    - Doesn't interfere too much with the code, no complex changes needed.

    - When handling more attestation verifications (e.g., sync module), a shared interface and metrics with appropriate
      namespace would be useful.

- error handling. I added base error handlers, for critical components. This can be extended to a higher level (I didn't
  want to disturb the readability of the code, with not much code interference)

- adding configuration, making metrics collector service with context support
- adding limitation:
    - length of reasons
    - watching for overflow
    - checking if the collector works
- prysm uses tracing, so this can be added to the tracking too